### PR TITLE
fix double encoded quotes

### DIFF
--- a/fields/field.textbox.php
+++ b/fields/field.textbox.php
@@ -146,7 +146,7 @@
 		}
 
 		protected function repairEntities($value) {
-			return preg_replace('/&(?!(#[0-9]+|#x[0-9a-f]+|amp|lt|gt);)/i', '&amp;', trim($value));
+			return preg_replace('/&(?!(#[0-9]+|#x[0-9a-f]+|amp|lt|gt|quot);)/i', '&amp;', trim($value));
 		}
 
 	/*-------------------------------------------------------------------------


### PR DESCRIPTION
Quotes would come double encoded when not using a formatter such as markdown, thus they would appear in the output as as `&quot;` which is not desired. This ensures that the quotes are not double encoded.

It doesn't seem like it could have any security related impact but confirmation would be appreciated.

@nitriques this was the issue I was referring to last time, sorry for the delay in posting it.