### PR TITLE
Unique Handle Option

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -63,6 +63,7 @@
 					`text_length` INT(11) UNSIGNED DEFAULT 0,
 					`text_cdata` ENUM('yes', 'no') DEFAULT 'no',
 					`text_handle` ENUM('yes', 'no') DEFAULT 'no',
+					`handle_unique` ENUM('yes', 'no') DEFAULT 'yes',
 					PRIMARY KEY (`id`),
 					KEY `field_id` (`field_id`)
 				) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;",
@@ -135,6 +136,13 @@
 			// Text handle:
 			if (!$this->updateHasColumn('text_handle')) {
 				$this->updateAddColumn('text_handle', "ENUM('yes', 'no') DEFAULT 'no' AFTER `text_cdata`");
+			}
+
+			// is handle unique:
+			if (!$this->updateHasColumn('handle_unique')) {
+				$this->updateAddColumn('handle_unique', "ENUM('yes', 'no') DEFAULT 'yes' AFTER `text_handle`");
+				//set default value
+				Symphony::Database()->update(array('handle_unique'=>'yes'),self::FIELD_TABLE);
 			}
 
 			// Add handle index to textbox entry tables:

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -21,6 +21,9 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="2.5.4" date="2016-04-14" min="2.6.0" max="2.x.x">
+			- Give option to make handle unique or not (default to unique as was before)
+		</release>
 		<release version="2.5.3" date="2016-03-17" min="2.6.0" max="2.x.x">
 			- Fix problem on update
 		</release>

--- a/fields/field.textbox.php
+++ b/fields/field.textbox.php
@@ -77,8 +77,8 @@
 		public function createHandle($value, $entry_id) {
 			$handle = Lang::createHandle(strip_tags(html_entity_decode($value)),160);
 
-			if ($this->isHandleLocked($handle, $entry_id)) {
-				if ($this->get('handle_unique') == 'no' || $this->isHandleFresh($handle, $value, $entry_id)) {
+			if ($this->isHandleLocked($handle, $entry_id) && $this->get('handle_unique') == 'yes') {
+				if ($this->isHandleFresh($handle, $value, $entry_id)) {
 					return $this->getCurrentHandle($entry_id);
 				}
 

--- a/fields/field.textbox.php
+++ b/fields/field.textbox.php
@@ -75,10 +75,10 @@
 	-------------------------------------------------------------------------*/
 
 		public function createHandle($value, $entry_id) {
-			$handle = Lang::createHandle(strip_tags(html_entity_decode($value)));
+			$handle = Lang::createHandle(strip_tags(html_entity_decode($value)),160);
 
 			if ($this->isHandleLocked($handle, $entry_id)) {
-				if ($this->isHandleFresh($handle, $value, $entry_id)) {
+				if ($this->get('handle_unique') == 'no' || $this->isHandleFresh($handle, $value, $entry_id)) {
 					return $this->getCurrentHandle($entry_id);
 				}
 
@@ -158,6 +158,7 @@
 			$settings['text_size'] = 'medium';
 			$settings['text_length'] = 0;
 			$settings['text_handle'] = 'yes';
+			$settings['handle_unique'] = 'yes';
 			$settings['text_cdata'] = 'no';
 		}
 
@@ -310,6 +311,29 @@
 			$label->setAttribute('class', 'column');
 			$columns->appendChild($label);
 
+			$input = Widget::Input(
+				"fields[{$order}][handle_unique]",
+				'no', 'hidden'
+			);
+			$columns->appendChild($input);
+
+			$input = Widget::Input(
+				"fields[{$order}][handle_unique]",
+				'yes', 'checkbox'
+			);
+
+			if ($this->get('handle_unique') == 'yes') {
+				$input->setAttribute('checked', 'checked');
+			}
+
+			$label = Widget::Label(
+				__('%s Handles are unique', array(
+					$input->generate()
+				))
+			);
+			$label->setAttribute('class', 'column');
+			$columns->appendChild($label);
+
 			$wrapper->appendChild($columns);
 
 		/*---------------------------------------------------------------------
@@ -334,7 +358,8 @@
 				'text_validator'	=> $this->get('text_validator'),
 				'text_length'		=> max((integer)$this->get('text_length'), 0),
 				'text_cdata'		=> $this->get('text_cdata'),
-				'text_handle'		=> $this->get('text_handle')
+				'text_handle'		=> $this->get('text_handle'),
+				'handle_unique'		=> $this->get('handle_unique')
 			);
 
 			return FieldManager::saveSettings($id, $fields);


### PR DESCRIPTION
The textbox field has always had unique handles adding an index `-2` `-3` etc to the actual handle to ensure uniqueness. This might not always be desired when something does not need to be unique. For example; First Names need not be unique.

Default behaviour remains as was prior to this pull request; as all fields are updated to set `unique` to `yes`.
