### PR TITLE
chore: Remove unnecessary interface includes

### DIFF
--- a/fields/field.textbox.php
+++ b/fields/field.textbox.php
@@ -6,10 +6,7 @@
 
 	if (!defined('__IN_SYMPHONY__')) die('<h2>Symphony Error</h2><p>You cannot directly access this file</p>');
 
-	require_once TOOLKIT . '/class.xsltprocess.php';
 	require_once EXTENSIONS . '/textboxfield/extension.driver.php';
-	require_once FACE . '/interface.exportablefield.php';
-	require_once FACE . '/interface.importablefield.php';
 
 	/**
 	 * An enhanced text input field.

--- a/fields/field.textbox.php
+++ b/fields/field.textbox.php
@@ -737,6 +737,17 @@
 		{
 			return array(
 				array(
+					'title'				=> 'contains',
+					'filter'			=> 'contains:',
+					'help'				=> __('Find values that contain the given string.')
+				),
+				array(
+					'title'				=> 'not-contains',
+					'filter'			=> 'not-contains:',
+					'help'				=> __('Find values that do not contain the given string.')
+				),
+
+				array(
 					'title'				=> 'boolean',
 					'filter'			=> 'boolean:',
 					'help'				=> __('Find values that match the given query. Can use operators <code>and</code> and <code>not</code>.')
@@ -760,17 +771,6 @@
 					'help'				=> __('Find values that do not match the given <a href="%s">MySQL regular expressions</a>.', array(
 						'http://dev.mysql.com/doc/mysql/en/Regexp.html'
 					))
-				),
-
-				array(
-					'title'				=> 'contains',
-					'filter'			=> 'contains:',
-					'help'				=> __('Find values that contain the given string.')
-				),
-				array(
-					'title'				=> 'not-contains',
-					'filter'			=> 'not-contains:',
-					'help'				=> __('Find values that do not contain the given string.')
 				),
 
 				array(


### PR DESCRIPTION
Since Symphony uses a composer classmap autoloader for all classes in `/lib` (see, [composer.json#L23](https://github.com/symphonycms/symphonycms/blob/68f44f0c36ad3345068676bfb8a61c2e6a2e51f4/composer.json#L23)), this commit removes the redundant require_once statements. Doing so avoids code breaking if `class.xsltprocess.php`,  `interface.exportablefield.php`, or `interface.importablefield.php` are renamed or they are no longer in `FACE` or `TOOLKIT`.